### PR TITLE
v2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "email": "f.klampfer@gmail.com"
   }],
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "react": "^0.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slider",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Slider component for React",
   "main": "react-slider.js",
   "scripts": {

--- a/react-slider.js
+++ b/react-slider.js
@@ -191,7 +191,7 @@
         document.removeEventListener('mousemove', self._dragMove(i), false);
         document.removeEventListener('mouseup', self._dragEnd(i), false);
         if (self.props.onChanged) {
-          self.props.onChanged(this.state.value);
+          self.props.onChanged(self.state.value);
         }
       }
     },


### PR DESCRIPTION
I ran into some trouble adding the slider to a project, so here comes the first wave of bug fixes:
- `_dragEnd` now removes the mouse event listeners. This had a serious performance impact and was just a really bad mistake on my part.
- `onChanged` is now being called correctly
- marked React as a dev dependency, so it won't be installed if you add the slider to another project via `npm install react-slider`. This was causing problems with browserfy.

Hope you can merge the fixes soon.
