### PR TITLE
fix: marks calculation when boolean or number is passed

### DIFF
--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -1102,10 +1102,10 @@ class ReactSlider extends React.Component {
         const range = this.props.max - this.props.min + 1;
 
         if (typeof marks === 'boolean') {
-            marks = Array.from({ length: range }).map((_, key) => key);
+            marks = Array.from({ length: range }).map((_, key) => key + this.props.min);
         } else if (typeof marks === 'number') {
             marks = Array.from({ length: range })
-                .map((_, key) => key)
+                .map((_, key) => key + this.props.min)
                 .filter(key => key % marks === 0);
         }
 

--- a/src/components/ReactSlider/__tests__/ReactSlider.test.js
+++ b/src/components/ReactSlider/__tests__/ReactSlider.test.js
@@ -320,4 +320,130 @@ describe('<ReactSlider>', () => {
         expect(mockRenderThumb).toHaveBeenCalledTimes(2);
         expect(mockRenderThumb.mock.calls[1][1].value).toBe(mockSecondValue);
     });
+
+    describe('marks prop', () => {
+        describe('boolean value', () => {
+            it('should not render marks if "false" is passed', () => {
+                const mockRenderMark = jest.fn();
+                renderer.create(
+                    <ReactSlider
+                        value={0}
+                        min={0}
+                        max={100}
+                        marks={false}
+                        renderMark={mockRenderMark}
+                    />
+                );
+
+                expect(mockRenderMark).not.toHaveBeenCalled();
+            });
+
+            it('should render marks if "true" is passed', () => {
+                const mockedMin = 0;
+                const mockedMax = 10;
+                const mockRenderMark = jest.fn();
+                renderer.create(
+                    <ReactSlider
+                        value={0}
+                        min={mockedMin}
+                        max={mockedMax}
+                        marks
+                        renderMark={mockRenderMark}
+                    />
+                );
+
+                expect(mockRenderMark).toHaveBeenCalledTimes(mockedMax + 1);
+                mockRenderMark.mock.calls.forEach(([call], index) => {
+                    expect(call.key).toBe(mockedMin + index);
+                });
+            });
+
+            it('should render marks if "true" is passed and "min" is not 0', () => {
+                const mockedMin = 10;
+                const mockedMax = 20;
+                const mockRenderMark = jest.fn();
+                renderer.create(
+                    <ReactSlider
+                        value={0}
+                        min={mockedMin}
+                        max={mockedMax}
+                        marks
+                        renderMark={mockRenderMark}
+                    />
+                );
+
+                expect(mockRenderMark).toHaveBeenCalledTimes(mockedMax - mockedMin + 1);
+                mockRenderMark.mock.calls.forEach(([call], index) => {
+                    expect(call.key).toBe(mockedMin + index);
+                });
+            });
+        });
+
+        describe('number value', () => {
+            it('should render correct marks', () => {
+                const mockedMin = 0;
+                const mockedMax = 10;
+                const mockedMarks = 2;
+                const mockRenderMark = jest.fn();
+                renderer.create(
+                    <ReactSlider
+                        value={0}
+                        min={mockedMin}
+                        max={mockedMax}
+                        marks={mockedMarks}
+                        renderMark={mockRenderMark}
+                    />
+                );
+
+                expect(mockRenderMark).toHaveBeenCalledTimes(6);
+                mockRenderMark.mock.calls.forEach(([call], index) => {
+                    expect(call.key).toBe(mockedMin + mockedMarks * index);
+                });
+            });
+
+            it('should render correct marks if "min" is not 0', () => {
+                const mockedMin = 10;
+                const mockedMax = 20;
+                const mockedMarks = 2;
+                const mockRenderMark = jest.fn();
+                renderer.create(
+                    <ReactSlider
+                        value={0}
+                        min={mockedMin}
+                        max={mockedMax}
+                        marks={mockedMarks}
+                        renderMark={mockRenderMark}
+                    />
+                );
+
+                expect(mockRenderMark).toHaveBeenCalledTimes(6);
+                mockRenderMark.mock.calls.forEach(([call], index) => {
+                    expect(call.key).toBe(mockedMin + mockedMarks * index);
+                });
+            });
+        });
+
+        describe('array of numbers is passed', () => {
+            it('should render correct marks', () => {
+                const mockedMin = 0;
+                const mockedMax = 10;
+                const mockedMarks = [1, 2, 3, 4, 5];
+                const mockRenderMark = jest.fn();
+                renderer.create(
+                    <ReactSlider
+                        value={0}
+                        min={mockedMin}
+                        max={mockedMax}
+                        marks={mockedMarks}
+                        renderMark={mockRenderMark}
+                    />
+                );
+
+                expect(mockRenderMark).toHaveBeenCalledTimes(mockedMarks.length);
+                mockRenderMark.mock.calls.forEach(([call], index) => {
+                    expect(call.key).toBe(mockedMarks[index]);
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Hi, I have found that `marks` property does not work correctly when `min` is not zero. You can open demo page and adjust the `min` property of "Slider with marks" example. In that case all marks are out of tracks. Of course I can calculate numbers by myself and pass an array of numbers but I think it is a good adjustment.

![image](https://github.com/zillow/react-slider/assets/28930553/c431ad0e-1bca-4a5e-978a-2e547ef535e0)

Also added tests for `marks` prop and covered marks logic by checking `key` property.