### PR TITLE
fix issue with pending state onSliderMouseClick when snap drag is disabled

### DIFF
--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -542,10 +542,10 @@ class ReactSlider extends React.Component {
             return;
         }
 
-        // Prevent controlled updates from happening while mouse is moving
-        this.setState({ pending: true });
-
         if (!this.props.snapDragDisabled) {
+            // Prevent controlled updates from happening while mouse is moving
+            this.setState({ pending: true });
+
             const position = this.getMousePosition(e);
             this.forceValueFromPosition(position[0], i => {
                 this.start(i, position[0]);


### PR DESCRIPTION
Fix for the issue [#315](https://github.com/zillow/react-slider/issues/315)

Looks like if snap drag is disabled, clicking on slider bar shouldn't set state.pending to true, because pending state remains and it prevents updates until thumb is dragged.